### PR TITLE
Fix rate limiting example

### DIFF
--- a/ex/rate-limiting.md
+++ b/ex/rate-limiting.md
@@ -18,7 +18,7 @@ main = do
     let loop1 = do
         req <- atomically $ do
             r <- readTQueue requests
-            readTMVar limitter
+            takeTMVar limitter
             return r
         now <- getCurrentTime
         putStrLn $ "request " ++ show req ++ " " ++ show now
@@ -60,14 +60,14 @@ main = do
 
 ```bash
 $ runhaskell rate-limiting.hs
-request 1 2015-05-10 08:35:48.533866 UTC
-request 2 2015-05-10 08:35:48.534358 UTC
-request 3 2015-05-10 08:35:48.534693 UTC
-request 4 2015-05-10 08:35:48.534944 UTC
-request 5 2015-05-10 08:35:48.53512 UTC
-request 1 2015-05-10 08:35:48.535557 UTC
-request 2 2015-05-10 08:35:48.535896 UTC
-request 3 2015-05-10 08:35:48.536174 UTC
-request 4 2015-05-10 08:35:48.536442 UTC
-request 5 2015-05-10 08:35:48.73627 UTC
+request 1 2018-10-18 21:22:30.873766 UTC
+request 2 2018-10-18 21:22:31.074185 UTC
+request 3 2018-10-18 21:22:31.274635 UTC
+request 4 2018-10-18 21:22:31.474943 UTC
+request 5 2018-10-18 21:22:31.675533 UTC
+request 1 2018-10-18 21:22:31.675713 UTC
+request 2 2018-10-18 21:22:31.675839 UTC
+request 3 2018-10-18 21:22:31.675947 UTC
+request 4 2018-10-18 21:22:31.676057 UTC
+request 5 2018-10-18 21:22:31.876147 UTC
 ```


### PR DESCRIPTION
Hi,
I've noticed that in the example of basic rate limiting ([https://lotz84.github.io/haskellbyexample/ex/rate-limiting](http://lotz84.github.io/haskellbyexample/ex/rate-limiting)) requests are received at a rate much faster than 1 request every 200 milliseconds.

The problem is that `readTMVar` doesn't 'take' the value from the `TMVar` and as a result of this, the `limitter` `TMVar` is always full. I've replaced `readTMVar` with `takeTMVar`, and now requests are handled once every ~200 milliseconds.